### PR TITLE
[FIX] Missing repo or org description or missing user bio

### DIFF
--- a/client/src/components/CreateChannel/index.js
+++ b/client/src/components/CreateChannel/index.js
@@ -152,7 +152,7 @@ export default class CreateChannel extends Component {
                 }
         })
 
-        description = ghRepoResponse.data.description
+        description = ghRepoResponse.data.description ? ghRepoResponse.data.description: ""
 
         const rcCreateChannelResponse = await axios({
             method: 'post',

--- a/client/src/components/CreateCommunity/index.js
+++ b/client/src/components/CreateCommunity/index.js
@@ -59,7 +59,7 @@ export default class CreateCommunity extends Component {
                     }
             })
 
-            description = ghOrgResponse.data.description
+            description = ghOrgResponse.data.description ? ghOrgResponse.data.description: ""
 
         }
         else
@@ -73,7 +73,7 @@ export default class CreateCommunity extends Component {
                     }
             })
 
-            description = ghUserResponse.data.bio
+            description = ghUserResponse.data.bio ? ghUserResponse.data.bio: ""
         }
         const rcCreateChannelResponse = await axios({
             method: 'post',


### PR DESCRIPTION
Covers case where a GitHub repository or organization might not have a description set or a user might not have their bio set. The GitHub API returns a `null` in these cases.