### PR TITLE
[FIX] Trigger Sort menu on sort button container click, Sort menu container ui

### DIFF
--- a/client/src/components/SignedLeftSidebar/index.css
+++ b/client/src/components/SignedLeftSidebar/index.css
@@ -139,7 +139,7 @@
 
 .menu-section-wrapper {
   outline: none;
-  padding: 10px 10px 0 10px;
+  padding: 10px 20px 0 20px;
 }
 
 .menu-section-title {

--- a/client/src/components/SignedLeftSidebar/index.js
+++ b/client/src/components/SignedLeftSidebar/index.js
@@ -280,8 +280,8 @@ export default function SignedLeftSidebar(props) {
           {showSearch ? (
             <SidebarSearch handleSearchClose={toggleShowSearch}></SidebarSearch>
           ) : null}
-          <div className="left-sidebar-control-icons">
-            <HiSortDescending onClick={openSortMenu} />
+          <div className="left-sidebar-control-icons" onClick={openSortMenu}>
+            <HiSortDescending />
           </div>
           <Menu
             id="sort-menu"


### PR DESCRIPTION
Now:
![image](https://user-images.githubusercontent.com/51796498/108604321-363a0d80-73d3-11eb-9076-3799605549f4.png)


Earlier:
![image](https://user-images.githubusercontent.com/51796498/108604336-49e57400-73d3-11eb-9beb-ad7575bfa7d4.png)
